### PR TITLE
Align neighbor and local-as highlighting with parser coverage

### DIFF
--- a/grammars/bird2.tmLanguage.json
+++ b/grammars/bird2.tmLanguage.json
@@ -698,6 +698,39 @@
           }
         },
         {
+          "name": "meta.neighbor-port-symbolic-statement.bird",
+          "match": "\\b(neighbor)\\s+((?:'[0-9A-Za-z_.:-]+'|(?!as\\b|range\\b)[A-Za-z_][A-Za-z0-9_]*))\\s*(%\\s*(?:'([0-9A-Za-z_.:-]+)'|([A-Za-z0-9_.:-]+)))?(?:\\s+(as)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*)))?\\s+(port)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*))\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.neighbor.bird"
+            },
+            "2": {
+              "name": "entity.name.symbol.neighbor-address.bird"
+            },
+            "3": {
+              "name": "meta.interface-reference.bird"
+            },
+            "4": {
+              "name": "string.quoted.single.interface.bird"
+            },
+            "5": {
+              "name": "variable.other.interface.bird"
+            },
+            "6": {
+              "name": "keyword.control.as.bird"
+            },
+            "7": {
+              "name": "constant.numeric.asn.bird"
+            },
+            "8": {
+              "name": "keyword.control.port.bird"
+            },
+            "9": {
+              "name": "constant.numeric.port.bird"
+            }
+          }
+        },
+        {
           "name": "meta.neighbor-statement.bird",
           "match": "\\b(neighbor)\\s+([0-9a-fA-F:.]+)\\s*(%\\s*(?:'([0-9A-Za-z_.:-]+)'|([A-Za-z0-9_.:-]+)))?\\s+(as)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*))\\b",
           "captures": {
@@ -706,6 +739,33 @@
             },
             "2": {
               "name": "constant.numeric.ip-address.bird"
+            },
+            "3": {
+              "name": "meta.interface-reference.bird"
+            },
+            "4": {
+              "name": "string.quoted.single.interface.bird"
+            },
+            "5": {
+              "name": "variable.other.interface.bird"
+            },
+            "6": {
+              "name": "keyword.control.as.bird"
+            },
+            "7": {
+              "name": "constant.numeric.asn.bird"
+            }
+          }
+        },
+        {
+          "name": "meta.neighbor-symbolic-statement.bird",
+          "match": "\\b(neighbor)\\s+((?:'[0-9A-Za-z_.:-]+'|(?!as\\b|range\\b)[A-Za-z_][A-Za-z0-9_]*))\\s*(%\\s*(?:'([0-9A-Za-z_.:-]+)'|([A-Za-z0-9_.:-]+)))?\\s+(as)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*))\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.neighbor.bird"
+            },
+            "2": {
+              "name": "entity.name.symbol.neighbor-address.bird"
             },
             "3": {
               "name": "meta.interface-reference.bird"

--- a/grammars/bird2.tmLanguage.json
+++ b/grammars/bird2.tmLanguage.json
@@ -666,7 +666,7 @@
         },
         {
           "name": "meta.neighbor-port-statement.bird",
-          "match": "\\b(neighbor)\\s+([0-9a-fA-F:.]+)\\s*(%\\s*(?:'([0-9A-Za-z_.:-]+)'|([A-Za-z0-9_.:-]+)))?(?:\\s+(as)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*)))?\\s+(port)\\s+([0-9]+)\\b",
+          "match": "\\b(neighbor)\\s+([0-9a-fA-F:.]+)\\s*(%\\s*(?:'([0-9A-Za-z_.:-]+)'|([A-Za-z0-9_.:-]+)))?(?:\\s+(as)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*)))?\\s+(port)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*))\\b",
           "captures": {
             "1": {
               "name": "keyword.control.neighbor.bird"

--- a/grammars/bird2.tmLanguage.json
+++ b/grammars/bird2.tmLanguage.json
@@ -626,8 +626,32 @@
     "neighbor-statements": {
       "patterns": [
         {
+          "name": "meta.local-as-statement.bird",
+          "match": "\\b(local)\\s+((?:[0-9a-fA-F:.]+|[A-Za-z_][A-Za-z0-9_]*|'[0-9A-Za-z_.:-]+'))(?:\\s+(port)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*)))?\\s+(as)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*))\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.local.bird"
+            },
+            "2": {
+              "name": "entity.name.symbol.local-address.bird"
+            },
+            "3": {
+              "name": "keyword.control.port.bird"
+            },
+            "4": {
+              "name": "constant.numeric.port.bird"
+            },
+            "5": {
+              "name": "keyword.control.as.bird"
+            },
+            "6": {
+              "name": "constant.numeric.asn.bird"
+            }
+          }
+        },
+        {
           "name": "meta.neighbor-statement.bird",
-          "match": "\\b(neighbor)\\s+([0-9a-fA-F:.]+)\\s*(%\\s*'([^']+)')?\\s+(as)\\s+([0-9]+)\\b",
+          "match": "\\b(neighbor)\\s+([0-9a-fA-F:.]+)\\s*(%\\s*(?:'([^']+)'|([A-Za-z0-9_.:-]+)))?\\s+(as)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*))\\b",
           "captures": {
             "1": {
               "name": "keyword.control.neighbor.bird"
@@ -642,9 +666,27 @@
               "name": "string.quoted.single.interface.bird"
             },
             "5": {
-              "name": "keyword.control.as.bird"
+              "name": "variable.other.interface.bird"
             },
             "6": {
+              "name": "keyword.control.as.bird"
+            },
+            "7": {
+              "name": "constant.numeric.asn.bird"
+            }
+          }
+        },
+        {
+          "name": "meta.neighbor-template-statement.bird",
+          "match": "\\b(neighbor)\\s+(as)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*))\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.neighbor.bird"
+            },
+            "2": {
+              "name": "keyword.control.as.bird"
+            },
+            "3": {
               "name": "constant.numeric.asn.bird"
             }
           }

--- a/grammars/bird2.tmLanguage.json
+++ b/grammars/bird2.tmLanguage.json
@@ -650,8 +650,56 @@
           }
         },
         {
+          "name": "meta.local-as-template-statement.bird",
+          "match": "\\b(local)\\s+(as)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*))\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.local.bird"
+            },
+            "2": {
+              "name": "keyword.control.as.bird"
+            },
+            "3": {
+              "name": "constant.numeric.asn.bird"
+            }
+          }
+        },
+        {
+          "name": "meta.neighbor-port-statement.bird",
+          "match": "\\b(neighbor)\\s+([0-9a-fA-F:.]+)\\s*(%\\s*(?:'([0-9A-Za-z_.:-]+)'|([A-Za-z0-9_.:-]+)))?(?:\\s+(as)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*)))?\\s+(port)\\s+([0-9]+)\\b",
+          "captures": {
+            "1": {
+              "name": "keyword.control.neighbor.bird"
+            },
+            "2": {
+              "name": "constant.numeric.ip-address.bird"
+            },
+            "3": {
+              "name": "meta.interface-reference.bird"
+            },
+            "4": {
+              "name": "string.quoted.single.interface.bird"
+            },
+            "5": {
+              "name": "variable.other.interface.bird"
+            },
+            "6": {
+              "name": "keyword.control.as.bird"
+            },
+            "7": {
+              "name": "constant.numeric.asn.bird"
+            },
+            "8": {
+              "name": "keyword.control.port.bird"
+            },
+            "9": {
+              "name": "constant.numeric.port.bird"
+            }
+          }
+        },
+        {
           "name": "meta.neighbor-statement.bird",
-          "match": "\\b(neighbor)\\s+([0-9a-fA-F:.]+)\\s*(%\\s*(?:'([^']+)'|([A-Za-z0-9_.:-]+)))?\\s+(as)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*))\\b",
+          "match": "\\b(neighbor)\\s+([0-9a-fA-F:.]+)\\s*(%\\s*(?:'([0-9A-Za-z_.:-]+)'|([A-Za-z0-9_.:-]+)))?\\s+(as)\\s+((?:[0-9]+|[A-Za-z_][A-Za-z0-9_]*))\\b",
           "captures": {
             "1": {
               "name": "keyword.control.neighbor.bird"

--- a/sample/protocol_phrases.conf
+++ b/sample/protocol_phrases.conf
@@ -38,6 +38,7 @@ protocol bgp upstream_1 {
   local OWNIPv6_rr port 1179 as AS_LOCAL;
   neighbor 2001:db8::10 as 64500;
   neighbor 2001:db8::10 port 179;
+  neighbor 2001:db8::10 port BGP_PORT;
   neighbor 2001:db8::11 % iface0 as PEER_AS;
   neighbor 2001:db8::12 % 'uplink-0' as PEER_AS;
   neighbor 2001:db8::13 % uplink1 port 180;

--- a/sample/protocol_phrases.conf
+++ b/sample/protocol_phrases.conf
@@ -37,8 +37,10 @@ protocol bgp upstream_1 {
   local 'loopback-main' port LOCAL_BGP_PORT as AS_LOCAL;
   local OWNIPv6_rr port 1179 as AS_LOCAL;
   neighbor 2001:db8::10 as 64500;
+  neighbor PEER_ADDR as PEER_AS;
   neighbor 2001:db8::10 port 179;
   neighbor 2001:db8::10 port BGP_PORT;
+  neighbor PEER_ADDR port BGP_PORT;
   neighbor 2001:db8::11 % iface0 as PEER_AS;
   neighbor 2001:db8::12 % 'uplink-0' as PEER_AS;
   neighbor 2001:db8::13 % uplink1 port 180;

--- a/sample/protocol_phrases.conf
+++ b/sample/protocol_phrases.conf
@@ -34,7 +34,10 @@ protocol babel babel_test {
 
 protocol bgp upstream_1 {
   local as AS_LOCAL;
+  local OWNIPv6_rr port 1179 as AS_LOCAL;
   neighbor 2001:db8::10 as 64500;
+  neighbor 2001:db8::11 % iface0 as PEER_AS;
+  neighbor as internal;
   source address 2001:db8::1;
   multihop 2;
   next hop self;

--- a/sample/protocol_phrases.conf
+++ b/sample/protocol_phrases.conf
@@ -34,9 +34,13 @@ protocol babel babel_test {
 
 protocol bgp upstream_1 {
   local as AS_LOCAL;
+  local 'loopback-main' port LOCAL_BGP_PORT as AS_LOCAL;
   local OWNIPv6_rr port 1179 as AS_LOCAL;
   neighbor 2001:db8::10 as 64500;
+  neighbor 2001:db8::10 port 179;
   neighbor 2001:db8::11 % iface0 as PEER_AS;
+  neighbor 2001:db8::12 % 'uplink-0' as PEER_AS;
+  neighbor 2001:db8::13 % uplink1 port 180;
   neighbor as internal;
   source address 2001:db8::1;
   multihop 2;


### PR DESCRIPTION
## Summary

- broaden `neighbor` statement highlighting for scoped interfaces and symbolic ASNs
- highlight `local <addr> port <port> as <asn>` forms
- add sample coverage for the new syntax shapes

## Why

BIRD-LSP recently expanded parser coverage for these forms while improving corpus compatibility. This PR keeps the TextMate grammar aligned with that coverage so syntax highlighting stays consistent.

Closes #9
