### PR TITLE
fix: address post-merge tooling review feedback

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,20 @@ repos:
         pass_filenames: false
         files: ^(grammars/bird2\.tmLanguage\.json|scripts/(?:check-grammar-coverage|grammar-patterns)\.js)$
 
+      - id: bird2-audit-cli-errors
+        name: Check upstream audit CLI errors
+        language: system
+        entry: node scripts/check-audit-cli-errors.js
+        pass_filenames: false
+        files: ^scripts/(?:audit-upstream-grammar|check-audit-cli-errors)\.js$
+
+      - id: bird2-install-smoke
+        name: Check compatibility installer layout
+        language: system
+        entry: bash scripts/check-install.sh
+        pass_filenames: false
+        files: ^(scripts/(?:install|check-install)\.sh|external/(?:bird2\.vim|bird2\.nvim))$
+
       - id: bird2-vim-source-check
         name: Source Vim syntax files headlessly
         language: system

--- a/scripts/audit-upstream-grammar.js
+++ b/scripts/audit-upstream-grammar.js
@@ -62,6 +62,25 @@ const internalAttributeClassNames = new Set(["krt_", "krt_features", "krt_lock"]
 const normalizeSourcePath = (value) =>
   isAbsolute(value) ? value : resolve(REPO_ROOT, value);
 
+const validateSourceDirectory = (sourceRoot) => {
+  try {
+    if (!statSync(sourceRoot).isDirectory()) {
+      return `BIRD source path is not a directory: ${sourceRoot}`;
+    }
+  } catch (error) {
+    const code =
+      error && typeof error === "object" && "code" in error ? error.code : null;
+    if (code === "ENOENT") {
+      return `BIRD source path does not exist: ${sourceRoot}`;
+    }
+
+    const detail = code ? ` (${code})` : "";
+    return `BIRD source path cannot be read: ${sourceRoot}${detail}`;
+  }
+
+  return null;
+};
+
 const listFiles = (root) => {
   const files = [];
 
@@ -244,10 +263,17 @@ const formatList = (values) =>
 
 const sourceArgs = process.argv.slice(2);
 const sources = sourceArgs.length > 0 ? sourceArgs : ["../BIRD2", "../BIRD3"];
+const sourceRoots = sources.map(normalizeSourcePath);
+const sourceErrors = sourceRoots.map(validateSourceDirectory).filter(Boolean);
+
+if (sourceErrors.length > 0) {
+  for (const error of sourceErrors) console.error(`Error: ${error}`);
+  process.exit(2);
+}
+
 let hasMissingCoverage = false;
 
-for (const sourceArg of sources) {
-  const sourceRoot = normalizeSourcePath(sourceArg);
+for (const sourceRoot of sourceRoots) {
   const { keywords, enumConstants, cliPhrases, attributeNames } =
     extractSourceGrammar(sourceRoot);
   const missingKeywords = [...keywords].filter((value) => !mentionsKeyword(value)).sort();

--- a/scripts/audit-upstream-grammar.js
+++ b/scripts/audit-upstream-grammar.js
@@ -68,8 +68,7 @@ const validateSourceDirectory = (sourceRoot) => {
       return `BIRD source path is not a directory: ${sourceRoot}`;
     }
   } catch (error) {
-    const code =
-      error && typeof error === "object" && "code" in error ? error.code : null;
+    const code = error?.code;
     if (code === "ENOENT") {
       return `BIRD source path does not exist: ${sourceRoot}`;
     }

--- a/scripts/check-audit-cli-errors.js
+++ b/scripts/check-audit-cli-errors.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const AUDIT_SCRIPT = join(SCRIPT_DIR, "audit-upstream-grammar.js");
+
+const missingPath = join(SCRIPT_DIR, "__missing-bird-source__");
+const cases = [
+  {
+    paths: [REPO_ROOT, missingPath],
+    invalidPath: missingPath,
+    message: "BIRD source path does not exist",
+  },
+  {
+    paths: [join(REPO_ROOT, "grammars", "bird2.tmLanguage.json")],
+    invalidPath: join(REPO_ROOT, "grammars", "bird2.tmLanguage.json"),
+    message: "BIRD source path is not a directory",
+  },
+];
+
+for (const check of cases) {
+  const result = spawnSync(process.execPath, [AUDIT_SCRIPT, ...check.paths], {
+    encoding: "utf8",
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 2) {
+    throw new Error(
+      `Expected audit exit code 2 for ${check.invalidPath}, got ${result.status}: ${result.stderr}`,
+    );
+  }
+  if (
+    !result.stderr.includes(check.message) ||
+    !result.stderr.includes(check.invalidPath)
+  ) {
+    throw new Error(`Unexpected audit error for ${check.invalidPath}: ${result.stderr}`);
+  }
+  if (result.stdout !== "") {
+    throw new Error(`Audit produced partial output before validation: ${result.stdout}`);
+  }
+}
+
+console.log("Upstream audit CLI error checks passed.");

--- a/scripts/check-grammar-coverage.js
+++ b/scripts/check-grammar-coverage.js
@@ -712,6 +712,27 @@ const checks = [
 
 const missing = [];
 
+const invalidPatternFixture = {
+  key: "match",
+  name: "invalid.regression.bird",
+  source: "(",
+};
+try {
+  compilePatterns([invalidPatternFixture]);
+  missing.push("Grammar regex validation: invalid regex was silently accepted");
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error);
+  for (const expected of [
+    invalidPatternFixture.key,
+    invalidPatternFixture.name,
+    JSON.stringify(invalidPatternFixture.source),
+  ]) {
+    if (!message.includes(expected)) {
+      missing.push(`Grammar regex validation: error omitted ${expected}`);
+    }
+  }
+}
+
 for (const check of checks) {
   for (const token of check.tokens) {
     const isScopeName = token.endsWith(".bird");

--- a/scripts/check-install.sh
+++ b/scripts/check-install.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bird2-install-check.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TEMP_DIR"
+}
+trap cleanup EXIT
+
+VIM_HOME="$TEMP_DIR/vim"
+XDG_CONFIG_HOME="$TEMP_DIR/xdg"
+
+HOME="$TEMP_DIR/home" \
+  VIM_HOME="$VIM_HOME" \
+  VIMRC="$TEMP_DIR/vimrc" \
+  XDG_CONFIG_HOME="$XDG_CONFIG_HOME" \
+  bash "$REPO_ROOT/scripts/install.sh" >/dev/null
+
+cmp "$REPO_ROOT/external/bird2.vim/syntax/bird2.vim" "$VIM_HOME/syntax/bird2.vim"
+cmp "$REPO_ROOT/external/bird2.vim/ftdetect/bird2.vim" "$VIM_HOME/ftdetect/bird2.vim"
+cmp "$REPO_ROOT/external/bird2.vim/ftplugin/bird2.vim" "$VIM_HOME/ftplugin/bird2.vim"
+cmp "$REPO_ROOT/external/bird2.vim/doc/bird2.txt" "$VIM_HOME/doc/bird2.txt"
+
+NVIM_HOME="$XDG_CONFIG_HOME/nvim"
+cmp "$REPO_ROOT/external/bird2.nvim/syntax/bird2.vim" "$NVIM_HOME/syntax/bird2.vim"
+cmp "$REPO_ROOT/external/bird2.nvim/plugin/bird2.lua" "$NVIM_HOME/plugin/bird2.lua"
+cmp "$REPO_ROOT/external/bird2.nvim/ftplugin/bird2.lua" "$NVIM_HOME/ftplugin/bird2.lua"
+cmp "$REPO_ROOT/external/bird2.nvim/doc/bird2.txt" "$NVIM_HOME/doc/bird2.txt"
+
+for module in config health init; do
+  cmp "$REPO_ROOT/external/bird2.nvim/lua/bird2/$module.lua" "$NVIM_HOME/lua/bird2/$module.lua"
+done
+
+if [[ -e "$NVIM_HOME/plugin/bird2-filetype.lua" ]]; then
+  echo "Unexpected legacy Neovim plugin filename: $NVIM_HOME/plugin/bird2-filetype.lua" >&2
+  exit 1
+fi
+
+echo "Compatibility installer layout check passed."

--- a/scripts/check-install.sh
+++ b/scripts/check-install.sh
@@ -12,6 +12,9 @@ trap cleanup EXIT
 
 VIM_HOME="$TEMP_DIR/vim"
 XDG_CONFIG_HOME="$TEMP_DIR/xdg"
+LEGACY_NVIM_PLUGIN="$XDG_CONFIG_HOME/nvim/plugin/bird2-filetype.lua"
+mkdir -p "$(dirname "$LEGACY_NVIM_PLUGIN")"
+printf '%s\n' '-- legacy installer output' >"$LEGACY_NVIM_PLUGIN"
 
 HOME="$TEMP_DIR/home" \
   VIM_HOME="$VIM_HOME" \
@@ -34,8 +37,8 @@ for module in config health init; do
   cmp "$REPO_ROOT/external/bird2.nvim/lua/bird2/$module.lua" "$NVIM_HOME/lua/bird2/$module.lua"
 done
 
-if [[ -e "$NVIM_HOME/plugin/bird2-filetype.lua" ]]; then
-  echo "Unexpected legacy Neovim plugin filename: $NVIM_HOME/plugin/bird2-filetype.lua" >&2
+if [[ -e "$LEGACY_NVIM_PLUGIN" || -L "$LEGACY_NVIM_PLUGIN" ]]; then
+  echo "Legacy Neovim plugin was not removed: $LEGACY_NVIM_PLUGIN" >&2
   exit 1
 fi
 

--- a/scripts/grammar-patterns.js
+++ b/scripts/grammar-patterns.js
@@ -21,11 +21,15 @@ export const collectGrammarPatterns = (value, patterns = []) => {
 };
 
 export const compilePatterns = (patterns) =>
-  patterns.flatMap((pattern) => {
+  patterns.map((pattern, index) => {
     try {
-      return [{ ...pattern, regex: new RegExp(pattern.source, "i") }];
-    } catch {
-      return [];
+      return { ...pattern, regex: new RegExp(pattern.source, "i") };
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      const scope = pattern.name || "<unnamed>";
+      throw new Error(
+        `Invalid grammar regex at index ${index} (${pattern.key}, ${scope}): ${JSON.stringify(pattern.source)} (${detail})`,
+      );
     }
   });
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -87,7 +87,7 @@ install_neovim() {
     "$NVIM_CONFIG_DIR/lua/bird2" \
     "$NVIM_CONFIG_DIR/doc"
   INSTALL_SYNTAX="$NVIM_CONFIG_DIR/syntax/bird2.vim"
-  INSTALL_PLUGIN="$NVIM_CONFIG_DIR/plugin/bird2-filetype.lua"
+  INSTALL_PLUGIN="$NVIM_CONFIG_DIR/plugin/bird2.lua"
   cp "$NVIM_PLUGIN_ROOT/syntax/bird2.vim" "$INSTALL_SYNTAX"
   cp "$NVIM_PLUGIN_ROOT/plugin/bird2.lua" "$INSTALL_PLUGIN"
   cp "$NVIM_PLUGIN_ROOT/ftplugin/bird2.lua" "$NVIM_CONFIG_DIR/ftplugin/bird2.lua"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -88,6 +88,11 @@ install_neovim() {
     "$NVIM_CONFIG_DIR/doc"
   INSTALL_SYNTAX="$NVIM_CONFIG_DIR/syntax/bird2.vim"
   INSTALL_PLUGIN="$NVIM_CONFIG_DIR/plugin/bird2.lua"
+  LEGACY_INSTALL_PLUGIN="$NVIM_CONFIG_DIR/plugin/bird2-filetype.lua"
+  if [[ -e "$LEGACY_INSTALL_PLUGIN" || -L "$LEGACY_INSTALL_PLUGIN" ]]; then
+    rm -f -- "$LEGACY_INSTALL_PLUGIN"
+    info "Removed legacy Neovim plugin: ${YELLOW}$LEGACY_INSTALL_PLUGIN${RESET}"
+  fi
   cp "$NVIM_PLUGIN_ROOT/syntax/bird2.vim" "$INSTALL_SYNTAX"
   cp "$NVIM_PLUGIN_ROOT/plugin/bird2.lua" "$INSTALL_PLUGIN"
   cp "$NVIM_PLUGIN_ROOT/ftplugin/bird2.lua" "$NVIM_CONFIG_DIR/ftplugin/bird2.lua"


### PR DESCRIPTION
## Context

Post-merge follow-up for the three review threads on PR #14. All follow-up review threads are resolved and CI is green.

## Changes

- Install the Neovim plugin as `plugin/bird2.lua`, matching the source repository layout.
- Remove the legacy `plugin/bird2-filetype.lua` during upgrades to prevent duplicate plugin loading.
- Make grammar regex compilation fail fast with the pattern index, key, scope, source, and compiler error.
- Validate every upstream source path before scanning and return exit code 2 for invalid input.
- Add automated regression checks for fresh and upgraded installer layouts, invalid regex diagnostics, missing paths, non-directory paths, and all-paths-before-output behavior.
- Simplify audit error-code extraction with optional chaining in response to review feedback.
- Run the new checks in Prek and CI.

## Validation

- `node scripts/check-grammar-coverage.js`
- `node scripts/check-audit-cli-errors.js`
- `node scripts/audit-upstream-grammar.js /abs/path/BIRD2 /abs/path/BIRD3`
- `bash scripts/check-install.sh`
- `shellcheck scripts/install.sh scripts/check-install.sh`
- `prek validate-config .pre-commit-config.yaml`
- `prek run --all-files --show-diff-on-failure`
- `actionlint`
- `git diff --check`

## Original review threads

- https://github.com/bird-chinese-community/BIRD-tm-language-grammar/pull/14#discussion_r3599950932
- https://github.com/bird-chinese-community/BIRD-tm-language-grammar/pull/14#discussion_r3599950947
- https://github.com/bird-chinese-community/BIRD-tm-language-grammar/pull/14#discussion_r3599950966
