### PR TITLE
Add bilingual changelog and change fragments

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -25,9 +25,9 @@ category: fixed
 
 - 🐛 **中文标题** / **English title**
 
-中文说明。
+  中文说明。
 
-English summary.
+  English summary.
 ```
 
 Supported bumps are `patch`, `minor`, and `major`. Supported categories are
@@ -41,8 +41,9 @@ node scripts/changeset.mjs check
 node scripts/changeset.mjs status
 ```
 
-CI runs `check` automatically. `status` lists pending fragments and reports the
-highest requested bump.
+CI runs `check` automatically. It validates the emoji, bilingual title,
+two-space paragraph indentation, and Chinese/English paragraph order. `status`
+lists pending fragments and reports the highest requested bump.
 
 To preview the notes for a version that is already in the changelog:
 

--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -1,0 +1,75 @@
+# Change fragments
+
+This repository uses a small, dependency-free change-fragment workflow inspired
+by the Changesets setup in BIRD-LSP. It keeps release notes reviewable in pull
+requests without introducing an npm package solely for release tooling.
+
+## Add a fragment
+
+Create a kebab-case fragment name and select its semantic-version bump and
+category:
+
+```sh
+node scripts/changeset.mjs new bright-birds patch fixed
+```
+
+Edit the generated file and replace both placeholder paragraphs. Release notes
+use the BIRD-LSP style: a bilingual title, followed by a Simplified Chinese
+paragraph and an English paragraph.
+
+```md
+---
+bump: patch
+category: fixed
+---
+
+- 🐛 **中文标题** / **English title**
+
+中文说明。
+
+English summary.
+```
+
+Supported bumps are `patch`, `minor`, and `major`. Supported categories are
+listed in `config.json`. Add a fragment for any user-visible or release-worthy
+change; purely internal test or CI maintenance may omit one.
+
+## Check pending changes
+
+```sh
+node scripts/changeset.mjs check
+node scripts/changeset.mjs status
+```
+
+CI runs `check` automatically. `status` lists pending fragments and reports the
+highest requested bump.
+
+To preview the notes for a version that is already in the changelog:
+
+```sh
+node scripts/changeset.mjs notes 1.0.13-20260717
+```
+
+Use inline Markdown links in fragments so extracted GitHub Release notes remain
+self-contained.
+
+## Prepare a release
+
+1. Inspect the pending fragments with `status`.
+2. Update the canonical grammar and syntax versions. For a patch release, use
+   `node scripts/bump-version.js --date YYYYMMDD` and review all mirrors.
+3. Preview the generated changelog section:
+
+   ```sh
+   node scripts/changeset.mjs release 1.0.14-20260718 \
+     --date 2026-07-18 --dry-run
+   ```
+
+4. Run the same command without `--dry-run`. It inserts the new bilingual
+   section in `CHANGELOG.md` and deletes the consumed fragments.
+5. Review and commit the resulting version/changelog diff. Existing release
+   automation continues to publish the `tm-v*` and `vim-v*` tracks.
+
+The change-fragment command intentionally does not edit version-bearing grammar
+files or create tags. Those steps remain explicit because this repository has
+two independently published release tracks.

--- a/.changeset/adopt-change-fragments.md
+++ b/.changeset/adopt-change-fragments.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+category: changed
+---
+
+- 🧾 **引入可审计的变更片段** / **Adopt auditable change fragments**
+
+新增零依赖的变更片段工作流，可在 PR 中记录语义版本级别和双语发布说明，
+发布时按分类汇总到 CHANGELOG，并让 TextMate/Vim Release 直接复用同一份说明。
+
+Added a dependency-free change-fragment workflow that records semantic version
+bumps and bilingual notes in pull requests, groups them into the changelog, and
+feeds the same notes into TextMate/Vim Releases.

--- a/.changeset/adopt-change-fragments.md
+++ b/.changeset/adopt-change-fragments.md
@@ -5,9 +5,9 @@ category: changed
 
 - 🧾 **引入可审计的变更片段** / **Adopt auditable change fragments**
 
-新增零依赖的变更片段工作流，可在 PR 中记录语义版本级别和双语发布说明，
-发布时按分类汇总到 CHANGELOG，并让 TextMate/Vim Release 直接复用同一份说明。
+  新增零依赖的变更片段工作流，可在 PR 中记录语义版本级别和双语发布说明，
+  发布时按分类汇总到 CHANGELOG，并让 TextMate/Vim Release 直接复用同一份说明。
 
-Added a dependency-free change-fragment workflow that records semantic version
-bumps and bilingual notes in pull requests, groups them into the changelog, and
-feeds the same notes into TextMate/Vim Releases.
+  Added a dependency-free change-fragment workflow that records semantic version
+  bumps and bilingual notes in pull requests, groups them into the changelog, and
+  feeds the same notes into TextMate/Vim Releases.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -28,6 +28,18 @@
       "heading": "📖 Documentation / 文档"
     },
     {
+      "id": "verification",
+      "heading": "🧪 Verification / 验证"
+    },
+    {
+      "id": "integrations",
+      "heading": "🔌 Editor integrations / 编辑器集成"
+    },
+    {
+      "id": "compatibility",
+      "heading": "🔌 Compatibility / 兼容性"
+    },
+    {
       "id": "security",
       "heading": "🔒 Security / 安全"
     }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,35 @@
+{
+  "project": "BIRD TextMate Grammar",
+  "changelog": "CHANGELOG.md",
+  "releaseLink": "https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/tm-v{version}",
+  "categories": [
+    {
+      "id": "breaking",
+      "heading": "💥 Breaking / 破坏性变更"
+    },
+    {
+      "id": "added",
+      "heading": "✨ Added / 新增"
+    },
+    {
+      "id": "changed",
+      "heading": "🔧 Changed / 变更"
+    },
+    {
+      "id": "fixed",
+      "heading": "🐛 Fixed / 修复"
+    },
+    {
+      "id": "performance",
+      "heading": "⚡ Performance / 性能"
+    },
+    {
+      "id": "documentation",
+      "heading": "📖 Documentation / 文档"
+    },
+    {
+      "id": "security",
+      "heading": "🔒 Security / 安全"
+    }
+  ]
+}

--- a/.changeset/post-release-hardening.md
+++ b/.changeset/post-release-hardening.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+category: fixed
+---
+
+- 🧰 **安装器与审计错误处理加固** / **Installer and audit error hardening**
+
+Neovim 安装器改用正确的 `plugin/bird2.lua` 并清理旧入口；grammar 审计现在会对
+无效正则和错误的上游源码路径快速失败，并给出可定位的诊断信息。
+
+The Neovim installer now uses the correct `plugin/bird2.lua` path and removes
+the legacy entry point. Grammar audits now fail fast on invalid regular
+expressions and invalid upstream source paths with actionable diagnostics.

--- a/.changeset/post-release-hardening.md
+++ b/.changeset/post-release-hardening.md
@@ -5,9 +5,9 @@ category: fixed
 
 - 🧰 **安装器与审计错误处理加固** / **Installer and audit error hardening**
 
-Neovim 安装器改用正确的 `plugin/bird2.lua` 并清理旧入口；grammar 审计现在会对
-无效正则和错误的上游源码路径快速失败，并给出可定位的诊断信息。
+  Neovim 安装器改用正确的 `plugin/bird2.lua` 并清理旧入口；grammar 审计现在会对
+  无效正则和错误的上游源码路径快速失败，并给出可定位的诊断信息。
 
-The Neovim installer now uses the correct `plugin/bird2.lua` path and removes
-the legacy entry point. Grammar audits now fail fast on invalid regular
-expressions and invalid upstream source paths with actionable diagnostics.
+  The Neovim installer now uses the correct `plugin/bird2.lua` path and removes
+  the legacy entry point. Grammar audits now fail fast on invalid regular
+  expressions and invalid upstream source paths with actionable diagnostics.

--- a/.changeset/rename-editor-repositories.md
+++ b/.changeset/rename-editor-repositories.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+category: documentation
+---
+
+- 🐦 **同步 BIRD.vim 与 BIRD.nvim 新名称** / **Adopt the BIRD.vim and BIRD.nvim names**
+
+文档、子模块链接和内置插件快照已切换到更名后的 BIRD.vim 与 BIRD.nvim 仓库，
+同时保留内部 `bird2` filetype 与运行时路径以维持兼容。
+
+Documentation, submodule links, and bundled plugin snapshots now use the
+renamed BIRD.vim and BIRD.nvim repositories while retaining the internal
+`bird2` filetype and runtime paths for compatibility.

--- a/.changeset/rename-editor-repositories.md
+++ b/.changeset/rename-editor-repositories.md
@@ -5,9 +5,9 @@ category: documentation
 
 - 🐦 **同步 BIRD.vim 与 BIRD.nvim 新名称** / **Adopt the BIRD.vim and BIRD.nvim names**
 
-文档、子模块链接和内置插件快照已切换到更名后的 BIRD.vim 与 BIRD.nvim 仓库，
-同时保留内部 `bird2` filetype 与运行时路径以维持兼容。
+  文档、子模块链接和内置插件快照已切换到更名后的 BIRD.vim 与 BIRD.nvim 仓库，
+  同时保留内部 `bird2` filetype 与运行时路径以维持兼容。
 
-Documentation, submodule links, and bundled plugin snapshots now use the
-renamed BIRD.vim and BIRD.nvim repositories while retaining the internal
-`bird2` filetype and runtime paths for compatibility.
+  Documentation, submodule links, and bundled plugin snapshots now use the
+  renamed BIRD.vim and BIRD.nvim repositories while retaining the internal
+  `bird2` filetype and runtime paths for compatibility.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ main ]
     paths:
+      - 'CHANGELOG.md'
       - 'grammars/bird2.tmLanguage.json'
       - 'grammars/bird2.syntax.vim'
       - 'external/bird2.vim'
@@ -46,6 +47,9 @@ jobs:
           notes_file=$(mktemp)
           printf '%s' "$TM_BODY" > "$notes_file"
           if gh release view "$TM_TAG" --json tagName >/dev/null 2>&1; then
+            gh release edit "$TM_TAG" \
+              --title "$TM_NAME" \
+              --notes-file "$notes_file"
             gh release upload "$TM_TAG" grammars/bird2.tmLanguage.json --clobber
           else
             gh release create "$TM_TAG" \
@@ -66,6 +70,9 @@ jobs:
           notes_file=$(mktemp)
           printf '%s' "$VIM_BODY" > "$notes_file"
           if gh release view "$VIM_TAG" --json tagName >/dev/null 2>&1; then
+            gh release edit "$VIM_TAG" \
+              --title "$VIM_NAME" \
+              --notes-file "$notes_file"
             gh release upload "$VIM_TAG" grammars/bird2.syntax.vim --clobber
           else
             gh release create "$VIM_TAG" \

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .worktrees/
 *.md
 !README*
+!CHANGELOG.md
+!.changeset/*.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,13 @@ repos:
         pass_filenames: false
         files: ^external/(bird2\.vim|bird2\.nvim)/syntax/bird2\.vim$
 
+      - id: bird2-changesets
+        name: Validate changelog changesets
+        language: system
+        entry: node scripts/changeset.mjs check
+        pass_filenames: false
+        files: ^(CHANGELOG\.md|\.changeset/|scripts/changeset\.mjs)$
+
       - id: commitlint
         name: Commit message lint (commitlint)
         language: node

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
         language: system
         entry: node scripts/changeset.mjs check
         pass_filenames: false
-        files: ^(CHANGELOG\.md|\.changeset/|scripts/changeset\.mjs)$
+        files: ^(CHANGELOG\.md|\.changeset/.*|scripts/changeset\.mjs)$
 
       - id: commitlint
         name: Commit message lint (commitlint)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,23 @@ snapshots are documented in this file.
 > constants, CLI phrases, filter attributes, and grammar behavior. They do not
 > cover upstream runtime semantics such as AS-SET defaults, disabled BGP
 > instance behavior, routing behavior, or memory management.
+>
+> 覆盖范围声明针对 BIRD 配置语法：关键字、枚举常量、CLI 短语、过滤器属性与
+> 语法行为；不涵盖上游运行时语义，如 AS-SET 默认值、BGP 实例禁用行为、
+> 路由行为或内存管理。
 
 <!-- changeset-release-marker -->
 
 ## [1.0.13-20260717] - 2026-07-17
 
-[TextMate Grammar 1.0.13-20260717] 与 [Vim Syntax 1.0.13-20260717] 已于
-2026-07-17 发布；本轮实现由 [PR #14] 合并。
+[TextMate Grammar 1.0.13-20260717](https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/tm-v1.0.13-20260717)
+与 [Vim Syntax 1.0.13-20260717](https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/vim-v1.0.13-20260717)
+已于 2026-07-17 发布；本轮实现由 [PR #14](https://github.com/bird-chinese-community/BIRD-tm-language-grammar/pull/14) 合并。
 
-[TextMate Grammar 1.0.13-20260717] and [Vim Syntax 1.0.13-20260717] were
-published on 2026-07-17. The implementation was merged in [PR #14].
+[TextMate Grammar 1.0.13-20260717](https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/tm-v1.0.13-20260717)
+and [Vim Syntax 1.0.13-20260717](https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/vim-v1.0.13-20260717)
+were published on 2026-07-17. The implementation was merged in
+[PR #14](https://github.com/bird-chinese-community/BIRD-tm-language-grammar/pull/14).
 
 ### ✨ Added / 新增
 
@@ -55,12 +62,14 @@ published on 2026-07-17. The implementation was merged in [PR #14].
 
   审计基准更新为 BIRD 2 `stable-v2.19` 的 `cb400b6c`（`v2.19.1`）与
   BIRD 3 `stable-v3.3` 的 `a69711d1`（`v3.3.1-1-ga69711d1`）。该基准仅表示
-  配置语法审计范围，不代表覆盖 [BIRD 3.3.0 与 2.19.0 发布公告]中的运行时变化。
+  配置语法审计范围，不代表覆盖
+  [BIRD 3.3.0 与 2.19.0 发布公告](https://bird.network.cz/pipermail/bird-users/2026-May/018761.html)
+  中的运行时变化。
 
   Audited BIRD 2 `stable-v2.19` at `cb400b6c` (`v2.19.1`) and BIRD 3
   `stable-v3.3` at `a69711d1` (`v3.3.1-1-ga69711d1`). These baselines describe
   configuration-syntax coverage only, not runtime changes in the
-  [BIRD 3.3.0 and 2.19.0 release announcement].
+  [BIRD 3.3.0 and 2.19.0 release announcement](https://bird.network.cz/pipermail/bird-users/2026-May/018761.html).
 
 - ⚙️ **操作符与匹配优先级校正** / **Operator and matching precedence alignment**
 
@@ -104,18 +113,15 @@ published on 2026-07-17. The implementation was merged in [PR #14].
 
 ### 🔌 Editor integrations / 编辑器集成
 
-- [BIRD.vim PR #3] 同步交付 Vim 语法、启发式文件识别、ftplugin 与兼容性测试。
-- [BIRD.vim PR #3] delivered the Vim syntax, heuristic file detection,
+- [BIRD.vim PR #3](https://github.com/bird-chinese-community/BIRD.vim/pull/3)
+  同步交付 Vim 语法、启发式文件识别、ftplugin 与兼容性测试。
+- [BIRD.vim PR #3](https://github.com/bird-chinese-community/BIRD.vim/pull/3)
+  delivered the Vim syntax, heuristic file detection,
   ftplugin behavior, and compatibility tests.
-- [BIRD.nvim PR #1] 同步交付 Neovim runtime、文件识别、CI 与语法镜像修复。
-- [BIRD.nvim PR #1] delivered the Neovim runtime, detection, CI, and syntax
+- [BIRD.nvim PR #1](https://github.com/bird-chinese-community/BIRD.nvim/pull/1)
+  一并带来 Neovim runtime、文件识别、CI 与语法镜像修复。
+- [BIRD.nvim PR #1](https://github.com/bird-chinese-community/BIRD.nvim/pull/1)
+  shipped the Neovim runtime, detection, CI, and syntax
   mirror fixes.
 
 [1.0.13-20260717]: https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/tm-v1.0.13-20260717
-[TextMate Grammar 1.0.13-20260717]: https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/tm-v1.0.13-20260717
-[Vim Syntax 1.0.13-20260717]: https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/vim-v1.0.13-20260717
-[PR #14]: https://github.com/bird-chinese-community/BIRD-tm-language-grammar/pull/14
-[BIRD.vim PR #3]: https://github.com/bird-chinese-community/BIRD.vim/pull/3
-[BIRD.nvim PR #1]: https://github.com/bird-chinese-community/BIRD.nvim/pull/1
-[BIRD 3.3.0 与 2.19.0 发布公告]: https://bird.network.cz/pipermail/bird-users/2026-May/018761.html
-[BIRD 3.3.0 and 2.19.0 release announcement]: https://bird.network.cz/pipermail/bird-users/2026-May/018761.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,121 @@
+# Changelog 🕊️
+
+<!-- markdownlint-disable MD024 -->
+
+All notable changes to the BIRD TextMate grammar and its shared editor syntax
+snapshots are documented in this file.
+
+本文记录 BIRD TextMate grammar 及其共享编辑器语法快照的重要变更。
+
+> Coverage statements refer to BIRD configuration syntax: keywords, enum
+> constants, CLI phrases, filter attributes, and grammar behavior. They do not
+> cover upstream runtime semantics such as AS-SET defaults, disabled BGP
+> instance behavior, routing behavior, or memory management.
+
+<!-- changeset-release-marker -->
+
+## [1.0.13-20260717] - 2026-07-17
+
+[TextMate Grammar 1.0.13-20260717] 与 [Vim Syntax 1.0.13-20260717] 已于
+2026-07-17 发布；本轮实现由 [PR #14] 合并。
+
+[TextMate Grammar 1.0.13-20260717] and [Vim Syntax 1.0.13-20260717] were
+published on 2026-07-17. The implementation was merged in [PR #14].
+
+### ✨ Added / 新增
+
+- 🛰️ **扩展当前与冷门语法覆盖** / **Broader current and uncommon syntax coverage**
+
+  补齐 EVPN、Bridge、BMP、RADV、BGP、OSPF、MRT、Perf 等模块，以及 table
+  类型、日志与时间格式、CLI 控制短语、枚举常量、运行时/接口属性和 BGP
+  hidden/unknown attributes。
+
+  Expanded coverage across EVPN, Bridge, BMP, RADV, BGP, OSPF, MRT, Perf,
+  table types, logging and time formats, CLI controls, enum constants,
+  runtime/interface attributes, and BGP hidden/unknown attributes.
+
+- 🧬 **新增类型与测试内置函数** / **New types and test built-ins**
+
+  新增 `mac`、`mac set` 类型及声明高亮，并补齐 `bt_check_assign` 等测试内置函数。
+
+  Added declaration highlighting for `mac` and `mac set`, together with test
+  built-ins including `bt_check_assign`.
+
+- 🔎 **上游源码自动覆盖审计** / **Automated upstream source coverage audit**
+
+  新增基于 BIRD 2/3 上游源码的关键字、枚举、CLI 短语和 BIRD 3
+  filter 属性审计，并加入 BIRD 2.19 / 3.3 回归样例。
+
+  Added source-driven audits for BIRD 2/3 keywords, enums, CLI phrases, and
+  BIRD 3 filter attributes, plus a BIRD 2.19 / 3.3 regression fixture.
+
+### 🔧 Changed / 变更
+
+- 🧭 **对齐当前稳定分支** / **Aligned with current stable branches**
+
+  审计基准更新为 BIRD 2 `stable-v2.19` 的 `cb400b6c`（`v2.19.1`）与
+  BIRD 3 `stable-v3.3` 的 `a69711d1`（`v3.3.1-1-ga69711d1`）。该基准仅表示
+  配置语法审计范围，不代表覆盖 [BIRD 3.3.0 与 2.19.0 发布公告]中的运行时变化。
+
+  Audited BIRD 2 `stable-v2.19` at `cb400b6c` (`v2.19.1`) and BIRD 3
+  `stable-v3.3` at `a69711d1` (`v3.3.1-1-ga69711d1`). These baselines describe
+  configuration-syntax coverage only, not runtime changes in the
+  [BIRD 3.3.0 and 2.19.0 release announcement].
+
+- ⚙️ **操作符与匹配优先级校正** / **Operator and matching precedence alignment**
+
+  正确区分位运算符 `&`、`|` 与逻辑运算符，并调整通用标识符规则顺序，避免覆盖
+  更具体的语法组；Vim 与 Neovim 语法镜像保持逐字节一致。
+
+  Distinguished bitwise `&` and `|` from logical operators, reordered the
+  generic identifier rule so specialized groups retain priority, and kept the
+  Vim/Neovim syntax mirrors byte-identical.
+
+### 🐛 Fixed / 修复
+
+- 🧵 **字符串、IPv6 与前缀范围匹配** / **Strings, IPv6, and prefix ranges**
+
+  修复双引号字符串转义、压缩 IPv6 前缀（如 `::/0`），以及 IPv4/IPv6
+  prefix range 后缀（如 `+`、`{16,24}`）的匹配。
+
+  Fixed double-quoted escapes, compressed IPv6 prefixes such as `::/0`, and
+  IPv4/IPv6 prefix-range suffixes such as `+` and `{16,24}`.
+
+- ⚡ **限制 IPv6 正则边界** / **Bounded IPv6 matching**
+
+  收紧 IPv6 前缀匹配边界并限制表达式工作量，避免异常长行触发不必要的性能开销。
+
+  Tightened IPv6 prefix boundaries and bounded matching work to avoid
+  unnecessary cost on unusually long lines.
+
+### 🧪 Verification / 验证
+
+- BIRD 2：581 个关键字、67 个枚举常量、114 个 CLI 短语，当前审计零遗漏。
+- BIRD 2: 581 keywords, 67 enum constants, and 114 CLI phrases, with zero
+  missing in the current audit.
+- BIRD 3：554 个关键字、67 个枚举常量、120 个 CLI 短语、90 个过滤器属性，
+  当前审计零遗漏。
+- BIRD 3: 554 keywords, 67 enum constants, 120 CLI phrases, and 90 filter
+  attributes, with zero missing in the current audit.
+- 162 条 grammar 正则均可成功编译；仓库守卫另覆盖 567 个 token、3 个 phrase、
+  4 个 operator 与 5 个 prefix 检查。
+- All 162 grammar regular expressions compile; repository guards additionally
+  cover 567 tokens, 3 phrases, 4 operators, and 5 prefix checks.
+
+### 🔌 Editor integrations / 编辑器集成
+
+- [BIRD.vim PR #3] 同步交付 Vim 语法、启发式文件识别、ftplugin 与兼容性测试。
+- [BIRD.vim PR #3] delivered the Vim syntax, heuristic file detection,
+  ftplugin behavior, and compatibility tests.
+- [BIRD.nvim PR #1] 同步交付 Neovim runtime、文件识别、CI 与语法镜像修复。
+- [BIRD.nvim PR #1] delivered the Neovim runtime, detection, CI, and syntax
+  mirror fixes.
+
+[1.0.13-20260717]: https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/tm-v1.0.13-20260717
+[TextMate Grammar 1.0.13-20260717]: https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/tm-v1.0.13-20260717
+[Vim Syntax 1.0.13-20260717]: https://github.com/bird-chinese-community/BIRD-tm-language-grammar/releases/tag/vim-v1.0.13-20260717
+[PR #14]: https://github.com/bird-chinese-community/BIRD-tm-language-grammar/pull/14
+[BIRD.vim PR #3]: https://github.com/bird-chinese-community/BIRD.vim/pull/3
+[BIRD.nvim PR #1]: https://github.com/bird-chinese-community/BIRD.nvim/pull/1
+[BIRD 3.3.0 与 2.19.0 发布公告]: https://bird.network.cz/pipermail/bird-users/2026-May/018761.html
+[BIRD 3.3.0 and 2.19.0 release announcement]: https://bird.network.cz/pipermail/bird-users/2026-May/018761.html

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ This repository uses **Prek** as the pre-commit runner.
 4. Bump patch version for tm grammar + Vim/Neovim syntax snapshots:
    - `node scripts/bump-version.js --dry-run`
    - `node scripts/bump-version.js`
+5. For release-worthy changes, add a bilingual change fragment. See the
+   [changelog](CHANGELOG.md) and [change-fragment guide](.changeset/README.md).
 
 ## Project Status
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -140,6 +140,8 @@ Neovim (使用 lazy.nvim):
 4. 快速提升 tm 语法 + Vim/Neovim 语法快照的 patch 版本：
    - `node scripts/bump-version.js --dry-run`
    - `node scripts/bump-version.js`
+5. 对需要进入发布说明的变更，请添加双语 change fragment。参见
+   [更新日志](CHANGELOG.md)与 [change fragment 指南](.changeset/README.md)。
 
 ### 进展公示
 

--- a/scripts/changeset.mjs
+++ b/scripts/changeset.mjs
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import {
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+  sep,
+} from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const CHANGESET_DIR = join(ROOT, ".changeset");
+const CONFIG_PATH = join(CHANGESET_DIR, "config.json");
+const RELEASE_MARKER = "<!-- changeset-release-marker -->";
+const BUMPS = ["patch", "minor", "major"];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function repositoryPath(value, label) {
+  if (typeof value !== "string" || value.length === 0 || isAbsolute(value)) {
+    fail(`${label} must be a non-empty repository-relative path`);
+  }
+  const target = resolve(ROOT, value);
+  const fromRoot = relative(ROOT, target);
+  if (fromRoot === ".." || fromRoot.startsWith(`..${sep}`)) {
+    fail(`${label} must stay inside the repository`);
+  }
+  return target;
+}
+
+function readConfig() {
+  let config;
+  try {
+    config = JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+  } catch (error) {
+    fail(`Cannot read .changeset/config.json: ${error.message}`);
+  }
+
+  if (typeof config.project !== "string" || config.project.length === 0) {
+    fail("config.project must be a non-empty string");
+  }
+  repositoryPath(config.changelog, "config.changelog");
+  if (config.releaseLink !== undefined && typeof config.releaseLink !== "string") {
+    fail("config.releaseLink must be a string when provided");
+  }
+  if (config.releaseLink !== undefined && !config.releaseLink.includes("{version}")) {
+    fail("config.releaseLink must contain the {version} placeholder");
+  }
+  if (!Array.isArray(config.categories) || config.categories.length === 0) {
+    fail("config.categories must be a non-empty array");
+  }
+
+  const ids = new Set();
+  for (const category of config.categories) {
+    if (
+      !category ||
+      typeof category.id !== "string" ||
+      !/^[a-z][a-z0-9-]*$/.test(category.id) ||
+      typeof category.heading !== "string" ||
+      category.heading.length === 0
+    ) {
+      fail("each changelog category needs a valid id and heading");
+    }
+    if (ids.has(category.id)) fail(`duplicate category id: ${category.id}`);
+    ids.add(category.id);
+  }
+
+  return { ...config, categoryIds: ids };
+}
+
+function parseFragment(name, source, config) {
+  const normalized = source.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n");
+  if (lines[0] !== "---") fail(`${name}: missing opening frontmatter delimiter`);
+  const closing = lines.indexOf("---", 1);
+  if (closing < 0) fail(`${name}: missing closing frontmatter delimiter`);
+
+  const metadata = {};
+  for (const line of lines.slice(1, closing)) {
+    const match = /^([a-z][a-z0-9-]*):\s*(\S(?:.*\S)?)\s*$/.exec(line);
+    if (!match) fail(`${name}: invalid frontmatter line: ${line}`);
+    if (metadata[match[1]] !== undefined) {
+      fail(`${name}: duplicate frontmatter key: ${match[1]}`);
+    }
+    metadata[match[1]] = match[2];
+  }
+
+  const allowed = new Set(["bump", "category"]);
+  for (const key of Object.keys(metadata)) {
+    if (!allowed.has(key)) fail(`${name}: unsupported frontmatter key: ${key}`);
+  }
+  if (!BUMPS.includes(metadata.bump)) {
+    fail(`${name}: bump must be one of ${BUMPS.join(", ")}`);
+  }
+  if (!config.categoryIds.has(metadata.category)) {
+    fail(`${name}: unknown category: ${metadata.category}`);
+  }
+
+  const body = lines.slice(closing + 1).join("\n").trim();
+  if (!body) fail(`${name}: release-note body must not be empty`);
+  if (!body.startsWith("- ")) fail(`${name}: release-note body must start with a list item`);
+  if (body.includes(RELEASE_MARKER)) fail(`${name}: release marker is not allowed in fragment body`);
+  const placeholders = ["中文标题", "English title", "中文说明。", "English summary."];
+  if (placeholders.some((placeholder) => body.includes(placeholder))) {
+    fail(`${name}: replace all generated template placeholders`);
+  }
+
+  return { name, bump: metadata.bump, category: metadata.category, body };
+}
+
+function readFragments(config) {
+  const names = readdirSync(CHANGESET_DIR, { withFileTypes: true })
+    .filter((entry) => entry.name.endsWith(".md") && entry.name !== "README.md")
+    .map((entry) => {
+      if (!entry.isFile()) fail(`${entry.name}: changesets must be regular files`);
+      return entry.name;
+    })
+    .sort();
+
+  return names.map((name) => {
+    if (!/^[a-z0-9]+(?:-[a-z0-9]+)*\.md$/.test(name)) {
+      fail(`${name}: filename must be kebab-case`);
+    }
+    return parseFragment(name, readFileSync(join(CHANGESET_DIR, name), "utf8"), config);
+  });
+}
+
+function readChangelog(config) {
+  const changelogPath = repositoryPath(config.changelog, "config.changelog");
+  const changelog = readFileSync(changelogPath, "utf8");
+  const markers = changelog.split(RELEASE_MARKER).length - 1;
+  if (markers !== 1) {
+    fail(`${config.changelog} must contain exactly one ${RELEASE_MARKER}`);
+  }
+  return { changelog, changelogPath };
+}
+
+function notesFor(changelog, version) {
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    fail("notes requires a semantic version");
+  }
+  const escaped = version.replaceAll(".", "\\.");
+  const heading = new RegExp(
+    `^## (?:\\[)?${escaped}(?:\\])? - \\d{4}-\\d{2}-\\d{2}$`,
+  );
+  const lines = changelog.replace(/\r\n/g, "\n").split("\n");
+  const start = lines.findIndex((line) => heading.test(line));
+  if (start < 0) fail(`CHANGELOG does not contain version ${version}`);
+  const next = lines.findIndex((line, index) => index > start && line.startsWith("## "));
+  const notes = lines.slice(start + 1, next < 0 ? undefined : next).join("\n").trim();
+  if (!notes) fail(`CHANGELOG version ${version} has no release notes`);
+  return notes;
+}
+
+function recommendedBump(fragments) {
+  return fragments.reduce(
+    (highest, fragment) =>
+      BUMPS.indexOf(fragment.bump) > BUMPS.indexOf(highest) ? fragment.bump : highest,
+    "patch",
+  );
+}
+
+function sectionFor(version, date, config, fragments) {
+  const title = config.releaseLink ? `[${version}]` : version;
+  const sections = [`## ${title} - ${date}`];
+  for (const category of config.categories) {
+    const matching = fragments.filter((fragment) => fragment.category === category.id);
+    if (matching.length === 0) continue;
+    sections.push(`### ${category.heading}`);
+    sections.push(matching.map((fragment) => fragment.body).join("\n\n"));
+  }
+  return sections.join("\n\n");
+}
+
+function today() {
+  const now = new Date();
+  const year = String(now.getFullYear());
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function help() {
+  process.stdout.write(`Usage: node scripts/changeset.mjs <command>\n\nCommands:\n  new <slug> <patch|minor|major> <category>\n  check\n  status\n  notes <version>\n  release <version> [--date YYYY-MM-DD] [--dry-run]\n`);
+}
+
+function createFragment(args, config) {
+  if (args.length !== 3) fail("new requires <slug> <bump> <category>");
+  const [slug, bump, category] = args;
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) fail("slug must be kebab-case");
+  if (!BUMPS.includes(bump)) fail(`bump must be one of ${BUMPS.join(", ")}`);
+  if (!config.categoryIds.has(category)) fail(`unknown category: ${category}`);
+
+  const target = join(CHANGESET_DIR, `${slug}.md`);
+  if (existsSync(target)) fail(`changeset already exists: ${slug}.md`);
+  const template = `---\nbump: ${bump}\ncategory: ${category}\n---\n\n- **中文标题** / **English title**\n\n中文说明。\n\nEnglish summary.\n`;
+  writeFileSync(target, template, { encoding: "utf8", flag: "wx" });
+  process.stdout.write(`Created .changeset/${slug}.md\n`);
+}
+
+function printStatus(config, fragments) {
+  process.stdout.write(`${config.project}\n`);
+  process.stdout.write(`Pending changesets: ${fragments.length}\n`);
+  if (fragments.length === 0) return;
+  process.stdout.write(`Recommended bump: ${recommendedBump(fragments)}\n`);
+  for (const fragment of fragments) {
+    const summary = fragment.body.split("\n", 1)[0].replace(/^-\s*/, "");
+    process.stdout.write(`- ${fragment.name} [${fragment.bump}/${fragment.category}] ${summary}\n`);
+  }
+}
+
+function release(args, config, fragments) {
+  if (fragments.length === 0) fail("no pending changesets to release");
+  const version = args.shift();
+  if (!version || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
+    fail("release requires a semantic version");
+  }
+
+  let date = today();
+  let dryRun = false;
+  while (args.length > 0) {
+    const arg = args.shift();
+    if (arg === "--dry-run") dryRun = true;
+    else if (arg === "--date") {
+      date = args.shift();
+      if (!date) fail("--date requires YYYY-MM-DD");
+    } else fail(`unknown release option: ${arg}`);
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) fail("date must use YYYY-MM-DD");
+
+  const { changelog, changelogPath } = readChangelog(config);
+  const heading = config.releaseLink ? `## [${version}]` : `## ${version}`;
+  if (changelog.includes(heading)) fail(`CHANGELOG already contains version ${version}`);
+
+  const section = sectionFor(version, date, config, fragments);
+  if (dryRun) {
+    process.stdout.write(`${section}\n`);
+    return;
+  }
+
+  const [before, after] = changelog.split(RELEASE_MARKER);
+  let next = `${before.trimEnd()}\n\n${RELEASE_MARKER}\n\n${section}\n\n${after.trimStart()}`;
+  if (config.releaseLink) {
+    const link = `[${version}]: ${config.releaseLink.replaceAll("{version}", version)}`;
+    if (next.includes(`${link}\n`) || next.endsWith(link)) fail(`CHANGELOG already defines ${version}`);
+    next = `${next.trimEnd()}\n${link}\n`;
+  } else {
+    next = `${next.trimEnd()}\n`;
+  }
+
+  const temporary = `${changelogPath}.tmp-${process.pid}`;
+  try {
+    writeFileSync(temporary, next, "utf8");
+    renameSync(temporary, changelogPath);
+  } finally {
+    if (existsSync(temporary)) unlinkSync(temporary);
+  }
+  for (const fragment of fragments) unlinkSync(join(CHANGESET_DIR, fragment.name));
+  process.stdout.write(`Released ${version}; consumed ${fragments.length} changeset(s).\n`);
+}
+
+function main() {
+  const [command = "help", ...args] = process.argv.slice(2);
+  if (command === "help" || command === "--help" || command === "-h") {
+    help();
+    return;
+  }
+
+  const config = readConfig();
+  if (command === "new") {
+    createFragment(args, config);
+    return;
+  }
+
+  const { changelog } = readChangelog(config);
+  if (command === "notes") {
+    if (args.length !== 1) fail("notes requires <version>");
+    process.stdout.write(`${notesFor(changelog, args[0])}\n`);
+    return;
+  }
+  const fragments = readFragments(config);
+  if (command === "check") {
+    process.stdout.write(`Validated ${fragments.length} pending changeset(s).\n`);
+  } else if (command === "status") {
+    printStatus(config, fragments);
+  } else if (command === "release") {
+    release(args, config, fragments);
+  } else {
+    fail(`unknown command: ${command}`);
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`changeset: ${error.message}\n`);
+  process.exitCode = 1;
+}

--- a/scripts/changeset.mjs
+++ b/scripts/changeset.mjs
@@ -34,7 +34,7 @@ function repositoryPath(value, label) {
   }
   const target = resolve(ROOT, value);
   const fromRoot = relative(ROOT, target);
-  if (fromRoot === ".." || fromRoot.startsWith(`..${sep}`)) {
+  if (fromRoot === ".." || isAbsolute(fromRoot) || fromRoot.startsWith(`..${sep}`)) {
     fail(`${label} must stay inside the repository`);
   }
   return target;
@@ -80,6 +80,58 @@ function readConfig() {
   return { ...config, categoryIds: ids };
 }
 
+function validateBilingualBody(name, body) {
+  const lines = body.split("\n");
+  const title = lines[0];
+  const firstBold = title.indexOf("**");
+  const separator = title.indexOf("** / **", firstBold + 2);
+  if (
+    !title.startsWith("- ") ||
+    firstBold <= 2 ||
+    separator < 0 ||
+    !title.endsWith("**")
+  ) {
+    fail(`${name}: title must use "- emoji **中文标题** / **English title**"`);
+  }
+
+  const icon = title.slice(2, firstBold).trim();
+  const chineseTitle = title.slice(firstBold + 2, separator);
+  const englishTitle = title.slice(separator + "** / **".length, -2);
+  if (!/\p{Extended_Pictographic}/u.test(icon)) {
+    fail(`${name}: title must start with an emoji`);
+  }
+  if (!/\p{Script=Han}/u.test(chineseTitle)) {
+    fail(`${name}: title must include a Simplified Chinese title first`);
+  }
+  if (!/[A-Za-z]/.test(englishTitle)) {
+    fail(`${name}: title must include an English title second`);
+  }
+
+  const paragraphs = [];
+  let current = [];
+  for (const line of lines.slice(1)) {
+    if (line.trim() === "") {
+      if (current.length > 0) paragraphs.push(current.join("\n"));
+      current = [];
+      continue;
+    }
+    if (!line.startsWith("  ")) {
+      fail(`${name}: paragraphs below the list item must use two-space indentation`);
+    }
+    current.push(line.slice(2));
+  }
+  if (current.length > 0) paragraphs.push(current.join("\n"));
+  if (paragraphs.length < 2) {
+    fail(`${name}: add a Chinese paragraph followed by an English paragraph`);
+  }
+  if (!/\p{Script=Han}/u.test(paragraphs[0])) {
+    fail(`${name}: first paragraph must be Simplified Chinese`);
+  }
+  if (!/[A-Za-z]/.test(paragraphs[paragraphs.length - 1])) {
+    fail(`${name}: final paragraph must be English`);
+  }
+}
+
 function parseFragment(name, source, config) {
   const normalized = source.replace(/\r\n/g, "\n");
   const lines = normalized.split("\n");
@@ -89,6 +141,7 @@ function parseFragment(name, source, config) {
 
   const metadata = {};
   for (const line of lines.slice(1, closing)) {
+    if (line.trim() === "") continue;
     const match = /^([a-z][a-z0-9-]*):\s*(\S(?:.*\S)?)\s*$/.exec(line);
     if (!match) fail(`${name}: invalid frontmatter line: ${line}`);
     if (metadata[match[1]] !== undefined) {
@@ -116,6 +169,7 @@ function parseFragment(name, source, config) {
   if (placeholders.some((placeholder) => body.includes(placeholder))) {
     fail(`${name}: replace all generated template placeholders`);
   }
+  validateBilingualBody(name, body);
 
   return { name, bump: metadata.bump, category: metadata.category, body };
 }
@@ -147,19 +201,51 @@ function readChangelog(config) {
   return { changelog, changelogPath };
 }
 
-function notesFor(changelog, version) {
+function versionHeadingPattern(version, command) {
   if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
-    fail("notes requires a semantic version");
+    fail(`${command} requires a semantic version`);
   }
-  const escaped = version.replaceAll(".", "\\.");
-  const heading = new RegExp(
-    `^## (?:\\[)?${escaped}(?:\\])? - \\d{4}-\\d{2}-\\d{2}$`,
+  const escaped = version.replace(/\./g, "\\.");
+  return new RegExp(
+    `^## (?:\\[${escaped}\\]|${escaped}) - \\d{4}-\\d{2}-\\d{2}\\s*$`,
   );
+}
+
+function findVersionStart(lines, version, command) {
+  const heading = versionHeadingPattern(version, command);
+  return lines.findIndex((line) => heading.test(line));
+}
+
+function stripTrailingLinkDefinitions(lines) {
+  let end = lines.length;
+  while (end > 0 && lines[end - 1].trim() === "") end -= 1;
+
+  while (end > 0) {
+    const line = lines[end - 1].trim();
+    const delimiter = line.indexOf("]:");
+    const isLinkDefinition =
+      line.startsWith("[") &&
+      delimiter > 1 &&
+      line.slice(delimiter + 2).trim().length > 0;
+    if (!isLinkDefinition) break;
+    end -= 1;
+    while (end > 0 && lines[end - 1].trim() === "") end -= 1;
+  }
+
+  return lines.slice(0, end);
+}
+
+function notesFor(changelog, version) {
   const lines = changelog.replace(/\r\n/g, "\n").split("\n");
-  const start = lines.findIndex((line) => heading.test(line));
+  const start = findVersionStart(lines, version, "notes");
   if (start < 0) fail(`CHANGELOG does not contain version ${version}`);
-  const next = lines.findIndex((line, index) => index > start && line.startsWith("## "));
-  const notes = lines.slice(start + 1, next < 0 ? undefined : next).join("\n").trim();
+  const next = lines.findIndex(
+    (line, index) => index > start && line.trimEnd().startsWith("## "),
+  );
+  const noteLines = stripTrailingLinkDefinitions(
+    lines.slice(start + 1, next < 0 ? undefined : next),
+  );
+  const notes = noteLines.join("\n").trim();
   if (!notes) fail(`CHANGELOG version ${version} has no release notes`);
   return notes;
 }
@@ -173,8 +259,7 @@ function recommendedBump(fragments) {
 }
 
 function sectionFor(version, date, config, fragments) {
-  const title = config.releaseLink ? `[${version}]` : version;
-  const sections = [`## ${title} - ${date}`];
+  const sections = [`## [${version}] - ${date}`];
   for (const category of config.categories) {
     const matching = fragments.filter((fragment) => fragment.category === category.id);
     if (matching.length === 0) continue;
@@ -184,11 +269,46 @@ function sectionFor(version, date, config, fragments) {
   return sections.join("\n\n");
 }
 
+function runRegressionChecks() {
+  const fixture = [
+    "## [1.0.14] - 2026-07-18",
+    "",
+    "New notes.",
+    "",
+    "## [1.0.13] - 2026-07-17  ",
+    "",
+    "Old notes.",
+    "",
+    "[1.0.14]: https://example.invalid/1.0.14",
+    "[1.0.13]: https://example.invalid/1.0.13",
+    "",
+  ].join("\n");
+  if (notesFor(fixture, "1.0.13") !== "Old notes.") {
+    fail("internal regression: notes must exclude trailing link definitions");
+  }
+  const lines = fixture.split("\n");
+  if (findVersionStart(lines, "1.0.1", "check") >= 0) {
+    fail("internal regression: version matching must not use prefixes");
+  }
+  if (findVersionStart(lines, "1.0.13", "check") < 0) {
+    fail("internal regression: bracketed headings must be detected");
+  }
+  const section = sectionFor(
+    "1.0.1",
+    "2026-07-18",
+    { categories: [{ id: "fixed", heading: "🐛 Fixed / 修复" }] },
+    [{ category: "fixed", body: "- 🐛 **修复** / **Fix**" }],
+  );
+  if (!section.startsWith("## [1.0.1] - 2026-07-18")) {
+    fail("internal regression: generated headings must use brackets");
+  }
+}
+
 function today() {
   const now = new Date();
-  const year = String(now.getFullYear());
-  const month = String(now.getMonth() + 1).padStart(2, "0");
-  const day = String(now.getDate()).padStart(2, "0");
+  const year = String(now.getUTCFullYear());
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(now.getUTCDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
 
@@ -205,7 +325,9 @@ function createFragment(args, config) {
 
   const target = join(CHANGESET_DIR, `${slug}.md`);
   if (existsSync(target)) fail(`changeset already exists: ${slug}.md`);
-  const template = `---\nbump: ${bump}\ncategory: ${category}\n---\n\n- **中文标题** / **English title**\n\n中文说明。\n\nEnglish summary.\n`;
+  const categoryConfig = config.categories.find((item) => item.id === category);
+  const icon = categoryConfig.heading.split(" ", 1)[0];
+  const template = `---\nbump: ${bump}\ncategory: ${category}\n---\n\n- ${icon} **中文标题** / **English title**\n\n  中文说明。\n\n  English summary.\n`;
   writeFileSync(target, template, { encoding: "utf8", flag: "wx" });
   process.stdout.write(`Created .changeset/${slug}.md\n`);
 }
@@ -224,9 +346,7 @@ function printStatus(config, fragments) {
 function release(args, config, fragments) {
   if (fragments.length === 0) fail("no pending changesets to release");
   const version = args.shift();
-  if (!version || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version)) {
-    fail("release requires a semantic version");
-  }
+  versionHeadingPattern(version, "release");
 
   let date = today();
   let dryRun = false;
@@ -241,8 +361,10 @@ function release(args, config, fragments) {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) fail("date must use YYYY-MM-DD");
 
   const { changelog, changelogPath } = readChangelog(config);
-  const heading = config.releaseLink ? `## [${version}]` : `## ${version}`;
-  if (changelog.includes(heading)) fail(`CHANGELOG already contains version ${version}`);
+  const changelogLines = changelog.replace(/\r\n/g, "\n").split("\n");
+  if (findVersionStart(changelogLines, version, "release") >= 0) {
+    fail(`CHANGELOG already contains version ${version}`);
+  }
 
   const section = sectionFor(version, date, config, fragments);
   if (dryRun) {
@@ -253,8 +375,12 @@ function release(args, config, fragments) {
   const [before, after] = changelog.split(RELEASE_MARKER);
   let next = `${before.trimEnd()}\n\n${RELEASE_MARKER}\n\n${section}\n\n${after.trimStart()}`;
   if (config.releaseLink) {
-    const link = `[${version}]: ${config.releaseLink.replaceAll("{version}", version)}`;
-    if (next.includes(`${link}\n`) || next.endsWith(link)) fail(`CHANGELOG already defines ${version}`);
+    const linkPrefix = `[${version}]:`;
+    if (next.split(/\r?\n/).some((line) => line.startsWith(linkPrefix))) {
+      fail(`CHANGELOG already defines ${version}`);
+    }
+    const releaseUrl = config.releaseLink.replace(/\{version\}/g, version);
+    const link = `${linkPrefix} ${releaseUrl}`;
     next = `${next.trimEnd()}\n${link}\n`;
   } else {
     next = `${next.trimEnd()}\n`;
@@ -292,6 +418,7 @@ function main() {
   }
   const fragments = readFragments(config);
   if (command === "check") {
+    runRegressionChecks();
     process.stdout.write(`Validated ${fragments.length} pending changeset(s).\n`);
   } else if (command === "status") {
     printStatus(config, fragments);

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -5,6 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const https = require('https');
+const { execFileSync } = require('child_process');
 
 function getRepoContextOptional() {
   const repoEnv = process.env.GITHUB_REPOSITORY || '';
@@ -19,22 +20,12 @@ function readJson(filePath) {
   return JSON.parse(content);
 }
 
-function readChangelogNotes(filePath, version) {
-  const lines = fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n').split('\n');
-  const escaped = version.replaceAll('.', '\\.');
-  const heading = new RegExp(
-    `^## (?:\\[)?${escaped}(?:\\])? - \\d{4}-\\d{2}-\\d{2}$`
-  );
-  const start = lines.findIndex((line) => heading.test(line));
-  if (start < 0) {
-    throw new Error(`CHANGELOG.md does not contain release notes for ${version}`);
-  }
-  const next = lines.findIndex(
-    (line, index) => index > start && line.startsWith('## ')
-  );
-  const notes = lines.slice(start + 1, next < 0 ? undefined : next).join('\n').trim();
-  if (!notes) throw new Error(`CHANGELOG.md release ${version} has no notes`);
-  return notes;
+function readChangelogNotes(repoRoot, version) {
+  const changesetScript = path.join(repoRoot, 'scripts', 'changeset.mjs');
+  return execFileSync(process.execPath, [changesetScript, 'notes', version], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).trim();
 }
 
 function readVimVersion(filePath) {
@@ -143,16 +134,16 @@ async function main() {
   const args = process.argv.slice(2);
   const toGhaOutputs = args.includes('--gha-outputs');
 
-  const tmPath = path.join(__dirname, '..', 'grammars', 'bird2.tmLanguage.json');
-  const vimPath = path.join(__dirname, '..', 'grammars', 'bird2.syntax.vim');
-  const changelogPath = path.join(__dirname, '..', 'CHANGELOG.md');
+  const repoRoot = path.join(__dirname, '..');
+  const tmPath = path.join(repoRoot, 'grammars', 'bird2.tmLanguage.json');
+  const vimPath = path.join(repoRoot, 'grammars', 'bird2.syntax.vim');
 
   const tmVersion = readJson(tmPath).version;
   const vimVersion = readVimVersion(vimPath);
-  const tmNotes = readChangelogNotes(changelogPath, tmVersion);
+  const tmNotes = readChangelogNotes(repoRoot, tmVersion);
   const vimNotes = tmVersion === vimVersion
     ? tmNotes
-    : readChangelogNotes(changelogPath, vimVersion);
+    : readChangelogNotes(repoRoot, vimVersion);
 
   const tmTag = `tm-v${tmVersion}`;
   const vimTag = `vim-v${vimVersion}`;

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -19,6 +19,24 @@ function readJson(filePath) {
   return JSON.parse(content);
 }
 
+function readChangelogNotes(filePath, version) {
+  const lines = fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n').split('\n');
+  const escaped = version.replaceAll('.', '\\.');
+  const heading = new RegExp(
+    `^## (?:\\[)?${escaped}(?:\\])? - \\d{4}-\\d{2}-\\d{2}$`
+  );
+  const start = lines.findIndex((line) => heading.test(line));
+  if (start < 0) {
+    throw new Error(`CHANGELOG.md does not contain release notes for ${version}`);
+  }
+  const next = lines.findIndex(
+    (line, index) => index > start && line.startsWith('## ')
+  );
+  const notes = lines.slice(start + 1, next < 0 ? undefined : next).join('\n').trim();
+  if (!notes) throw new Error(`CHANGELOG.md release ${version} has no notes`);
+  return notes;
+}
+
 function readVimVersion(filePath) {
   let content;
   try {
@@ -79,7 +97,7 @@ async function listReleases(owner, repo, token) {
   return res.data || [];
 }
 
-function buildReleaseBody({ kind, version, owner, repo, previousTag, tag }) {
+function buildReleaseBody({ kind, version, owner, repo, previousTag, tag, notes }) {
   const repoUrl = owner && repo ? `https://github.com/${owner}/${repo}` : '';
   const compareLine = previousTag && repoUrl ? `Compare: ${repoUrl}/compare/${previousTag}...${tag}` : 'Initial release for this track.';
   const installLinks = repoUrl
@@ -93,6 +111,7 @@ function buildReleaseBody({ kind, version, owner, repo, previousTag, tag }) {
   return (
     `Release ${kind} - \`${version}\`\n\n` +
     `${compareLine}\n\n` +
+    `## Changes\n\n${notes}\n\n` +
     `## Installation\n${installLinks}`
   );
 }
@@ -126,9 +145,14 @@ async function main() {
 
   const tmPath = path.join(__dirname, '..', 'grammars', 'bird2.tmLanguage.json');
   const vimPath = path.join(__dirname, '..', 'grammars', 'bird2.syntax.vim');
+  const changelogPath = path.join(__dirname, '..', 'CHANGELOG.md');
 
   const tmVersion = readJson(tmPath).version;
   const vimVersion = readVimVersion(vimPath);
+  const tmNotes = readChangelogNotes(changelogPath, tmVersion);
+  const vimNotes = tmVersion === vimVersion
+    ? tmNotes
+    : readChangelogNotes(changelogPath, vimVersion);
 
   const tmTag = `tm-v${tmVersion}`;
   const vimTag = `vim-v${vimVersion}`;
@@ -141,8 +165,24 @@ async function main() {
   const owner = ctx ? ctx.owner : null;
   const repo = ctx ? ctx.repo : null;
 
-  const tmBody = buildReleaseBody({ kind: 'TextMate Grammar', version: tmVersion, owner, repo, previousTag: tmPrevious, tag: tmTag });
-  const vimBody = buildReleaseBody({ kind: 'Vim Syntax', version: vimVersion, owner, repo, previousTag: vimPrevious, tag: vimTag });
+  const tmBody = buildReleaseBody({
+    kind: 'TextMate Grammar',
+    version: tmVersion,
+    owner,
+    repo,
+    previousTag: tmPrevious,
+    tag: tmTag,
+    notes: tmNotes,
+  });
+  const vimBody = buildReleaseBody({
+    kind: 'Vim Syntax',
+    version: vimVersion,
+    owner,
+    repo,
+    previousTag: vimPrevious,
+    tag: vimTag,
+    notes: vimNotes,
+  });
 
   const tmName = `TextMate Grammar ${tmVersion}`;
   const vimName = `Vim Syntax ${vimVersion}`;


### PR DESCRIPTION
## Summary

- add a BIRD-LSP-style bilingual changelog for the published TextMate and Vim Syntax 1.0.13-20260717 releases
- scope upstream coverage claims to configuration syntax and retain the audited BIRD 2.19 / BIRD 3.3 counts
- add a dependency-free change-fragment workflow with `new`, `check`, `status`, `notes`, and `release` commands
- validate pending fragments in Prek and source GitHub Release notes from versioned changelog sections
- capture the already-merged post-release hardening and BIRD.vim/BIRD.nvim rename work as pending patch fragments

## Release accuracy

- TextMate Grammar and Vim Syntax 1.0.13-20260717 are recorded as published on 2026-07-17
- runtime semantic changes are explicitly outside the grammar coverage claim
- BIRD.vim and BIRD.nvim links use the renamed repositories

## Verification

- `node scripts/changeset.mjs check`
- `node scripts/changeset.mjs status`
- `node scripts/changeset.mjs notes 1.0.13-20260717`
- `node scripts/changeset.mjs release 1.0.14-20260718 --date 2026-07-18 --dry-run`
- `node scripts/release.js --gha-outputs`
- targeted `prek run --files ...`
- `actionlint .github/workflows/release.yml`
- `git diff --check`

## Review follow-up (2026-07-18)

- fix exact version detection, bracketed generated headings, oldest-version note extraction, UTC dates, cross-drive path validation, and Node.js compatibility
- generate emoji-prefixed, two-space-indented bilingual fragments and enforce their Chinese/English structure in CI
- fix the Prek file matcher so a fragment-only commit runs validation
- convert release-note links to inline Markdown and make `release.js` reuse the shared notes parser
- add config entries for verification, integrations, and compatibility sections, plus README workflow links
- add built-in regression fixtures for link-definition leakage and version-prefix false positives
- replied to and resolved all five inline review threads
