### PR TITLE
fix(release): accept aligned Vim version headers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           if [[ "$TRACK" == "tm" ]]; then
             jq -e --arg version "$VERSION" '.version == $version' "$ASSET"
           else
-            grep -Fqx '" Version: '"$VERSION" "$ASSET"
+            grep -Eq '^" Version:[[:space:]]+'"$VERSION"'[[:space:]]*$' "$ASSET"
             if [[ "$PRERELEASE" != "true" ]]; then
               vim -Nu NONE -n -es \
                 -c "execute 'source ' . fnameescape('$ASSET')" \


### PR DESCRIPTION
## Summary

- accept one or more spaces after the historical Vim `Version:` label
- keep the exact version value and full-line anchor strict
- unblock immutable restoration of `vim-v1.0.7-20260228`

## Root cause

The historical `v1.0.7` syntax header uses two spaces after `Version:`. The ESM exporter already parsed this correctly, but the workflow's fixed-string verification expected exactly one space and stopped before the headless Vim check or upload.

## Verification

- [x] exact `v1.0.7` tag export
- [x] updated version-header check
- [x] headless Vim source
- [x] `actionlint .github/workflows/*.yml`
- [x] `prek run --all-files`
