### PR TITLE
fix(release): compare Vim versions literally

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,13 @@ jobs:
           if [[ "$TRACK" == "tm" ]]; then
             jq -e --arg version "$VERSION" '.version == $version' "$ASSET"
           else
-            grep -Eq '^" Version:[[:space:]]+'"$VERSION"'[[:space:]]*$' "$ASSET"
+            header_version=$(sed -nE \
+              's/^" Version:[[:space:]]+([^[:space:]]+)[[:space:]]*$/\1/p' \
+              "$ASSET")
+            if [[ "$header_version" != "$VERSION" ]]; then
+              echo "Vim asset version $header_version does not match $VERSION" >&2
+              exit 1
+            fi
             if [[ "$PRERELEASE" != "true" ]]; then
               vim -Nu NONE -n -es \
                 -c "execute 'source ' . fnameescape('$ASSET')" \


### PR DESCRIPTION
## Summary

- extract the Vim header version with a value-independent regular expression
- compare the extracted token to the expected version with Bash literal string equality
- retain support for historically aligned whitespace without treating version dots as wildcards

## Verification

- [x] exact `vim-v1.0.7-20260228` export
- [x] two-space historical header extraction
- [x] literal match accepts `1.0.7-20260228`
- [x] literal match rejects `1x0x7-20260228`
- [x] headless Vim source
- [x] `actionlint .github/workflows/*.yml`
- [x] `prek run --all-files`

Follow-up to the valid inline finding on #19.
