### PR TITLE
fix(release): diagnose missing Vim versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,12 @@ jobs:
             header_version=$(sed -nE \
               's/^" Version:[[:space:]]+([^[:space:]]+)[[:space:]]*$/\1/p' \
               "$ASSET")
+            if [[ -z "$header_version" ]]; then
+              echo "Vim asset is missing a valid Version header" >&2
+              exit 1
+            fi
             if [[ "$header_version" != "$VERSION" ]]; then
-              echo "Vim asset version $header_version does not match $VERSION" >&2
+              echo "Vim asset version '$header_version' does not match '$VERSION'" >&2
               exit 1
             fi
             if [[ "$PRERELEASE" != "true" ]]; then


### PR DESCRIPTION
## Summary

- fail explicitly when no valid Vim `Version:` header can be extracted
- quote both actual and expected values in mismatch diagnostics
- preserve the literal-comparison and historical-whitespace behavior from #20

## Verification

- [x] historical two-space `v1.0.7` header is extracted
- [x] a file without a version header produces an empty extraction and takes the explicit failure path
- [x] `actionlint .github/workflows/*.yml`
- [x] `prek run --all-files`

Follow-up to the valid inline diagnostic finding on #20.
