### PR TITLE
fix(release): identify invalid Vim assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,11 +91,11 @@ jobs:
               's/^" Version:[[:space:]]+([^[:space:]]+)[[:space:]]*$/\1/p' \
               "$ASSET")
             if [[ -z "$header_version" ]]; then
-              echo "Vim asset is missing a valid Version header" >&2
+              echo "Vim asset '$ASSET' is missing a valid Version header" >&2
               exit 1
             fi
             if [[ "$header_version" != "$VERSION" ]]; then
-              echo "Vim asset version '$header_version' does not match '$VERSION'" >&2
+              echo "Vim asset '$ASSET' version '$header_version' does not match '$VERSION'" >&2
               exit 1
             fi
             if [[ "$PRERELEASE" != "true" ]]; then


### PR DESCRIPTION
## Summary

- include the validated asset path when a Vim version header is missing
- include the same asset path when the extracted version mismatches
- make both early-exit diagnostics actionable without relying on later log lines

## Verification

- [x] `actionlint .github/workflows/*.yml`
- [x] `prek run --all-files`
- [x] `git diff --check`

Follow-up to both inline diagnostic findings on #21.
