### PR TITLE
docs(install): clarify source checkout compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,11 @@ Neovim (using lazy.nvim):
 }
 ```
 
-**Backward Compatibility (still installable from this repo):**
+**Source-checkout compatibility installer (not recommended for new installs):**
+
+This repository keeps `scripts/install.sh` for existing source-checkout workflows. It installs
+the plugin snapshots referenced by the dedicated-repository submodules; it is not a second
+maintained distribution channel. New installations should use `BIRD.vim` or `BIRD.nvim` above.
 
 1. Clone this repository with its plugin sources: `git clone --recurse-submodules https://github.com/bird-chinese-community/bird-tm-language-grammar.git`
 2. Quick install: `bash scripts/install.sh` (installs Vim and Neovim)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -96,7 +96,11 @@ Neovim (使用 lazy.nvim):
 }
 ```
 
-**向后兼容（本仓库仍可安装）：**
+**源码检出兼容安装器（不建议新安装使用）：**
+
+本仓库保留 `scripts/install.sh`，用于兼容既有的源码检出工作流。该脚本安装的是独立仓库
+submodule 所锁定的插件快照，并不构成第二个维护或发布渠道；新安装应使用上方的
+`BIRD.vim` 或 `BIRD.nvim`。
 
 1. 连同插件源一起克隆此仓库：`git clone --recurse-submodules https://github.com/bird-chinese-community/bird-tm-language-grammar.git`
 2. 一键安装：`bash scripts/install.sh`（同时安装 Vim 和 Neovim）

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -27,11 +27,13 @@ Usage: scripts/install.sh [--vim] [--neovim]
 - Use --vim to install only Vim support.
 - Use --neovim to install only Neovim support.
 
-NOTE: Vim/Neovim support has moved to dedicated repositories:
+COMPATIBILITY NOTE: This installer is retained for existing source-checkout workflows.
+New installations should use the dedicated repositories:
   - Vim:   https://github.com/bird-chinese-community/BIRD.vim
   - Neovim: https://github.com/bird-chinese-community/BIRD.nvim
 
-Consider using the dedicated plugins for better maintenance and features.
+The submodules in this repository pin plugin snapshots; they are not a separate
+maintained distribution channel.
 EOF
 }
 
@@ -181,9 +183,11 @@ ${BOLD}Next steps:${RESET}
 You should see: ${YELLOW}filetype=bird2${RESET}
 ========================================
 
-${BLUE}${BOLD}NOTE:${RESET} Vim/Neovim support is now maintained in dedicated repositories:
+${BLUE}${BOLD}COMPATIBILITY NOTE:${RESET} This installer is retained for existing source-checkout workflows.
+New installations should use the dedicated repositories:
   - Vim:   ${GREEN}https://github.com/bird-chinese-community/BIRD.vim${RESET}
   - Neovim: ${GREEN}https://github.com/bird-chinese-community/BIRD.nvim${RESET}
 
-Consider using the dedicated plugins for automatic updates and better features!
+The submodules in this repository pin plugin snapshots; they are not a separate
+maintained distribution channel.
 EOF


### PR DESCRIPTION
## Summary

- label the root installer as a source-checkout compatibility path rather than a second distribution channel
- direct new Vim and Neovim installations to the standalone BIRD.vim and BIRD.nvim repositories
- preserve the existing submodule paths and installer for backward compatibility

## Validation

- `bash -n scripts/install.sh`
- `bash scripts/install.sh --help`
- `prek run --files README.md README.zh-CN.md scripts/install.sh`
- `git diff --check`